### PR TITLE
Rope bridges will no longer replace blocks in creative

### DIFF
--- a/src/main/java/com/terraformersmc/campanion/block/RopeBridgePostBlock.java
+++ b/src/main/java/com/terraformersmc/campanion/block/RopeBridgePostBlock.java
@@ -73,6 +73,14 @@ public class RopeBridgePostBlock extends RopeBridgePlanksBlock {
                                 return ActionResult.SUCCESS;
                             }
                             if (player.isCreative()) {
+                                for (Pair<BlockPos, ?> pair : planks) {
+                                    BlockPos planksPos = pair.getLeft();
+                                    if (!world.getBlockState(planksPos).getMaterial().isReplaceable() && world.getBlockState(planksPos).getBlock() != CampanionBlocks.ROPE_BRIDGE_POST) {
+                                        player.addChatMessage(new TranslatableText("message.campanion.rope_bridge.obstructed", planksPos.getX(), planksPos.getY(), planksPos.getZ(), new TranslatableText(world.getBlockState(planksPos).getBlock().getTranslationKey())), false);
+                                        return ActionResult.PASS;
+                                    }
+                                }
+
                                 planks.forEach(pair -> {
                                     BlockPos left = pair.getLeft();
                                     BlockEntity blockEntityTwo = world.getBlockEntity(left);
@@ -88,6 +96,7 @@ public class RopeBridgePostBlock extends RopeBridgePlanksBlock {
                                         ((RopeBridgePlanksBlockEntity) blockEntityTwo).sync();
                                     }
                                 });
+
                             } else {
                                 be.getGhostPlanks().put(clickedPos, planks);
                                 BlockEntity blockEntityTwo = world.getBlockEntity(clickedPos);


### PR DESCRIPTION
Small fix that checks block existence in Creative.