### PR TITLE
Add Nourish Tags

### DIFF
--- a/src/main/resources/data/nourish/carbohydrates.json
+++ b/src/main/resources/data/nourish/carbohydrates.json
@@ -1,0 +1,7 @@
+{
+	"values": [
+		"campanion:mre",
+		"campanion:cracker",
+		"campanion:smore"
+	]
+}

--- a/src/main/resources/data/nourish/fats.json
+++ b/src/main/resources/data/nourish/fats.json
@@ -1,0 +1,5 @@
+{
+	"values": [
+		"campanion:mre"
+	]
+}

--- a/src/main/resources/data/nourish/fruit.json
+++ b/src/main/resources/data/nourish/fruit.json
@@ -1,0 +1,5 @@
+{
+	"values": [
+		"campanion:mre"
+	]
+}

--- a/src/main/resources/data/nourish/protein.json
+++ b/src/main/resources/data/nourish/protein.json
@@ -1,0 +1,5 @@
+{
+	"values": [
+		"campanion:mre"
+	]
+}

--- a/src/main/resources/data/nourish/sweets.json
+++ b/src/main/resources/data/nourish/sweets.json
@@ -1,0 +1,9 @@
+{
+	"values": [
+		"campanion:mre",
+		"campanion:marshmallow",
+		"campanion:cooked_marshmallow",
+		"campanion:blackened_marshmallow",
+		"campanion:smore"
+	]
+}

--- a/src/main/resources/data/nourish/vegetables.json
+++ b/src/main/resources/data/nourish/vegetables.json
@@ -1,0 +1,5 @@
+{
+	"values": [
+		"campanion:mre"
+	]
+}


### PR DESCRIPTION
I've created [Nourish](https://www.curseforge.com/minecraft/mc-mods/nourish/) tags for the Campanion food items. I like the idea of putting the MREs in every food group except sweets. I just thought it made sense.