### PR TITLE
Fix light_gray_lawn_chair.json

### DIFF
--- a/src/main/resources/data/campanion/advancements/recipes/decorations/light_gray_lawn_chair.json
+++ b/src/main/resources/data/campanion/advancements/recipes/decorations/light_gray_lawn_chair.json
@@ -11,7 +11,7 @@
       "conditions": {
         "items": [
           {
-            a
+            "items": [ "minecraft:light_gray_carpet" ]
           }
         ]
       }


### PR DESCRIPTION
Simple fix based on error log that I've found while testing this mod, which complains about this file's invalid syntax.