### PR TITLE
Fix incompatibility with Visual Overhaul and tent previews

### DIFF
--- a/src/main/java/com/terraformersmc/campanion/client/renderer/item/FakeWorld.java
+++ b/src/main/java/com/terraformersmc/campanion/client/renderer/item/FakeWorld.java
@@ -72,7 +72,11 @@ public class FakeWorld extends ClientWorld {
 	public BlockEntity getBlockEntity(BlockPos pos) {
 		return this.blockEntityMap.computeIfAbsent(pos, p -> {
 			if (this.blockEntityTagMap.containsKey(p)) {
-				BlockEntity entity = BlockEntity.createFromNbt(pos ,getBlockState(pos), this.blockEntityTagMap.get(p));
+				BlockEntity entity = BlockEntity.createFromNbt(pos, getBlockState(pos), this.blockEntityTagMap.get(p));
+
+				assert entity != null;
+				entity.setWorld(this);
+
 				return entity;
 			}
 			return null;


### PR DESCRIPTION
Close #153 

Visual Overhauls relies on calling blockEntity.getWorld() and ensuring it is not null when passing the value as an argument when overriding default EntityRenderer behaviour for the blocks it tweaks (currently furnace, brewing stand and jukebox). This changes our FakeWorld implementation by ensuring the world for a block entities created inside it is set to the FakeWorld instance, rather than being null, which fixes the crash when rendering a tent preview with one of the modified blocks stored inside.