### PR TITLE
Fix cutout_mipped not rendering.

### DIFF
--- a/src/main/java/com/terraformersmc/campanion/client/util/TentPreviewImmediate.java
+++ b/src/main/java/com/terraformersmc/campanion/client/util/TentPreviewImmediate.java
@@ -3,10 +3,7 @@ package com.terraformersmc.campanion.client.util;
 import com.google.common.collect.ImmutableMap;
 import com.mojang.blaze3d.systems.RenderSystem;
 import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.client.render.BufferBuilder;
-import net.minecraft.client.render.BufferRenderer;
-import net.minecraft.client.render.RenderLayer;
-import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -31,37 +28,7 @@ public class TentPreviewImmediate extends VertexConsumerProvider.Immediate {
 	}
 
 	@Override
-	public void draw(RenderLayer layer) {
-		try {
-			BufferBuilder buffer = this.layerBuffers.getOrDefault(layer, this.fallbackBuffer);
-			boolean bl = Objects.equals(this.currentLayer, layer.asOptional());
-			if ((bl || buffer != this.fallbackBuffer) && this.activeConsumers.remove(buffer)) {
-				if (buffer.isBuilding()) {
-					buffer.sortFrom(0, 0, 0);
-
-					buffer.end();
-					layer.startDrawing();
-
-					RenderSystem.enableBlend();
-					RenderSystem.defaultBlendFunc();
-//					RenderSystem.defaultAlphaFunc(); may require shader change
-
-					BufferRenderer.draw(buffer);
-
-					RenderSystem.disableBlend();
-
-					layer.endDrawing();
-				}
-				if (bl) {
-					this.currentLayer = Optional.empty();
-				}
-			}
-		} catch (NoSuchFieldError e) {
-			if (FabricLoader.getInstance().isModLoaded("optifabric")) {
-				LOGGER.error("ERROR likely due to OptiFine - Could not find required field:", e);
-			} else {
-				throw e;
-			}
-		}
+	public VertexConsumer getBuffer(RenderLayer renderLayer) {
+		return super.getBuffer(RenderLayer.getTranslucent());
 	}
 }

--- a/src/main/java/com/terraformersmc/campanion/client/util/TentPreviewImmediate.java
+++ b/src/main/java/com/terraformersmc/campanion/client/util/TentPreviewImmediate.java
@@ -29,6 +29,7 @@ public class TentPreviewImmediate extends VertexConsumerProvider.Immediate {
 
 	@Override
 	public VertexConsumer getBuffer(RenderLayer renderLayer) {
+		//We always render as translucent, so might as well enfore it.
 		return super.getBuffer(RenderLayer.getTranslucent());
 	}
 }


### PR DESCRIPTION
Closes #167
Fixes the issue where `cutout_mipped` blocks do not render. 
We also don't need to override the `#draw` method, as the only reason beforehand was to ensure translucenty/blending was enabled.

Proof:
![image](https://user-images.githubusercontent.com/15876682/165375217-4286830c-eea4-47ef-bea1-835fd1711c4d.png)
